### PR TITLE
gl_rasterizer: Skip VAO binding if the state is clean.

### DIFF
--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -92,7 +92,15 @@ void Maxwell3D::WriteReg(u32 method, u32 value, u32 remaining_params) {
         debug_context->OnEvent(Tegra::DebugContext::Event::MaxwellCommandLoaded, nullptr);
     }
 
+    u32 old = regs.reg_array[method];
     regs.reg_array[method] = value;
+
+    if (value != old) {
+        if (method >= MAXWELL3D_REG_INDEX(vertex_attrib_format) &&
+            method < MAXWELL3D_REG_INDEX(vertex_attrib_format) + regs.vertex_attrib_format.size()) {
+            dirty_flags.vertex_attrib_format = true;
+        }
+    }
 
     switch (method) {
     case MAXWELL3D_REG_INDEX(macros.data): {

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -983,6 +983,12 @@ public:
     State state{};
     MemoryManager& memory_manager;
 
+    struct DirtyFlags {
+        bool vertex_attrib_format = true;
+    };
+
+    DirtyFlags dirty_flags;
+
     /// Reads a register value located at the input method address
     u32 GetRegisterValue(u32 method) const;
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -124,9 +124,14 @@ RasterizerOpenGL::RasterizerOpenGL(Core::Frontend::EmuWindow& window, ScreenInfo
 RasterizerOpenGL::~RasterizerOpenGL() {}
 
 void RasterizerOpenGL::SetupVertexFormat() {
-    MICROPROFILE_SCOPE(OpenGL_VAO);
-    const auto& gpu = Core::System::GetInstance().GPU().Maxwell3D();
+    auto& gpu = Core::System::GetInstance().GPU().Maxwell3D();
     const auto& regs = gpu.regs;
+
+    if (!gpu.dirty_flags.vertex_attrib_format)
+        return;
+    gpu.dirty_flags.vertex_attrib_format = false;
+
+    MICROPROFILE_SCOPE(OpenGL_VAO);
 
     auto [iter, is_cache_miss] = vertex_array_cache.try_emplace(regs.vertex_attrib_format);
     auto& VAO = iter->second;

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -207,7 +207,8 @@ private:
 
     std::size_t CalculateIndexBufferSize() const;
 
-    void SetupVertexArrays();
+    void SetupVertexFormat();
+    void SetupVertexBuffer();
 
     DrawParameters SetupDraw();
 


### PR DESCRIPTION
This PR starts with the idea to skip some state lookups if the state is clean. This shall reduce the overhead per draw call a tiny bit.